### PR TITLE
Fix Escaping and Like Operator Prefix

### DIFF
--- a/filter_processor_test.go
+++ b/filter_processor_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var fp = newFilterProcessor("")
+
 var offsetFilter = &Filter{
 	Offset: 1,
 }
@@ -28,22 +30,23 @@ var sortFilter = &Filter{
 // integers are converted to float64 because that is what the json unmarshaller do
 var basicWhereFilter = &Filter{
 	Where: []map[string]interface{}{{
-		"password":   "qwertyuiop",
-		"age":        float64(22),
-		"money":      3000.55,
-		"awesome":    true,
-		"notAwesome": false,
-		"graduated":  []interface{}{float64(2010), float64(2015)},
-		"avg":        []interface{}{15.5, 13.24},
-		"birthPlace": []interface{}{"Chalon", "Macon"},
-		"bools":      []interface{}{true, false},
+		"password":     "qwertyuiop",
+		"age":          float64(22),
+		"money":        3000.55,
+		"awesome":      true,
+		"notAwesome":   false,
+		"graduated":    []interface{}{float64(2010), float64(2015)},
+		"avg":          []interface{}{15.5, 13.24},
+		"birthPlace":   []interface{}{"Chalon", "Macon"},
+		"bools":        []interface{}{true, false},
+		"strWithQuote": "O'Hare",
 	}},
 }
 
 var orWhereFilter = &Filter{
 	Where: []map[string]interface{}{{
 		"oR": []interface{}{
-			map[string]interface{}{"lastName": map[string]interface{}{"eq": "Fabien"}},
+			map[string]interface{}{"lastName": map[string]interface{}{"eq": "O'Connor"}},
 			map[string]interface{}{"age": map[string]interface{}{"gt": float64(23)}},
 			map[string]interface{}{"age": map[string]interface{}{"lt": float64(26)}},
 		}},
@@ -61,7 +64,7 @@ var andWhereFilter = &Filter{
 
 var notWhereFilter = &Filter{
 	Where: []map[string]interface{}{
-		{"not": map[string]interface{}{"firstName": "Fabien"}},
+		{"not": map[string]interface{}{"firstName": "D'Arcy"}},
 		{"nOt": map[string]interface{}{
 			"or": []interface{}{
 				map[string]interface{}{"lastName": "Herfray"},
@@ -72,64 +75,96 @@ var notWhereFilter = &Filter{
 }
 
 var likeWhereFilter = &Filter{
-	Where: []map[string]interface{}{{
-		"like": map[string]interface{}{
+	Where: []map[string]interface{}{
+		{"like": map[string]interface{}{
 			"text":             "firstName",
 			"search":           "fab%",
 			"case_insensitive": true,
-		},
-	}},
+		}},
+		{"like": map[string]interface{}{
+			"text":             "lastName",
+			"search":           "Her%",
+			"case_insensitive": false,
+		}},
+	},
 }
 
-// TestProcessFilter runs tests on the filter processor Process method.
-func TestProcessFilter(t *testing.T) {
+func newAssertRequire(t *testing.T) (*assert.Assertions, *require.Assertions) {
 	a := assert.New(t)
 	r := require.New(t)
-	fp := newFilterProcessor("")
+	return a, r
+}
 
-	// Offset and limit filters
+// Offset and limit filters
+func TestProcessOffsetFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
 	p, err := fp.Process(offsetFilter)
 	r.NoError(err)
 	a.Equal("1", p.OffsetLimit)
+}
 
-	p, err = fp.Process(limitFilter)
+func TestProcessLimitFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(limitFilter)
 	r.NoError(err)
 	a.Equal("2", p.OffsetLimit)
+}
 
-	p, err = fp.Process(offsetLimitFilter)
+func TestProcessOffsetLimitFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(offsetLimitFilter)
 	r.NoError(err)
 	a.Equal("3, 4", p.OffsetLimit)
+}
 
-	p, err = fp.Process(&Filter{Offset: -1})
+func TestProcessNegativeOffsetFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Offset: -1})
 	r.NoError(err)
 	a.NotNil(p)
+}
 
-	p, err = fp.Process(&Filter{Limit: -1})
+func TestProcessNegativeLimitFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Limit: -1})
 	r.NoError(err)
 	a.NotNil(p)
+}
 
-	// Sort filter
-	p, err = fp.Process(sortFilter)
+func TestProcessSortFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(sortFilter)
 	r.NoError(err)
 	a.Equal("var.firstName ASC, var.lastName DESC, var.age ASC", p.Sort)
+}
 
-	p, err = fp.Process(&Filter{Sort: []string{}})
+func TestProcessEmptySortFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Sort: []string{}})
 	r.NoError(err)
 	a.Equal("", p.Sort)
+}
 
-	p, err = fp.Process(&Filter{Sort: []string{"foo, bar"}})
+func TestProcessInvalidCharacterSortFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Sort: []string{"foo, bar"}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Sort: []string{"INSeRT ASC"}})
+func TestProcessInvalidUsingOperatorSortFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Sort: []string{"INSeRT ASC"}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	// Where filter
-	p, err = fp.Process(basicWhereFilter)
+func TestProcessBasicWhereFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(basicWhereFilter)
 	r.NoError(err)
 	split := strings.Split(p.Where, " && ")
-	a.Equal(9, len(split))
+	a.Equal(10, len(split))
 	expected := []string{
 		`var.awesome == true`,
 		`var.graduated IN [2010, 2015]`,
@@ -140,83 +175,148 @@ func TestProcessFilter(t *testing.T) {
 		`var.money == 3000.55`,
 		`var.notAwesome == false`,
 		`var.bools IN [true, false]`,
+		`var.strWithQuote == 'O\'Hare'`,
 	}
 	for _, s := range split {
 		a.Contains(expected, s)
 	}
+}
 
-	p, err = fp.Process(orWhereFilter)
+func TestProcessOrWhereFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(orWhereFilter)
 	r.NoError(err)
-	a.Equal(`(var.lastName == 'Fabien' || var.age > 23 || var.age < 26)`, p.Where)
+	a.Equal(`(var.lastName == 'O\'Connor' || var.age > 23 || var.age < 26)`, p.Where)
+}
 
-	p, err = fp.Process(andWhereFilter)
+func TestProcessAndWhereFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(andWhereFilter)
 	r.NoError(err)
 	a.Equal(`(var.firstName != 'Toto' && var.money == 200.5)`, p.Where)
+}
 
-	p, err = fp.Process(notWhereFilter)
+func TestProcessNotWhereFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(notWhereFilter)
 	r.NoError(err)
-	split = strings.Split(p.Where, " && ")
+	split := strings.Split(p.Where, " && ")
 	a.Equal(2, len(split))
-	expected = []string{
-		`!(var.firstName == 'Fabien')`,
+	expected := []string{
+		`!(var.firstName == 'D\'Arcy')`,
 		`!((var.lastName == 'Herfray' || var.money >= 0 || var.money <= 1000.5))`,
 	}
 	for _, s := range split {
 		a.Contains(expected, s)
 	}
+}
 
-	p, err = fp.Process(likeWhereFilter)
+func TestProcessLikeWhereFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(likeWhereFilter)
 	r.NoError(err)
-	a.Contains(`LIKE(var.firstName, 'fab%', true)`, p.Where)
+	split := strings.Split(p.Where, " && ")
+	expected := []string{
+		`LIKE(var.firstName, 'fab%', true)`,
+		`LIKE(var.lastName, 'Her%')`,
+	}
+	for _, s := range split {
+		a.Contains(expected, s)
+	}
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"var.firstName": []interface{}{"foo", map[string]interface{}{"foo": "bar"}}}}})
+func TestProcessInvalidSimpleConditionTypeFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"var.firstName": []interface{}{"foo", map[string]interface{}{"foo": "bar"}}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"and": []interface{}{"foo", "bar"}}}})
+func TestProcessInvalidAndMapConditionTypeFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"and": []interface{}{"foo", "bar"}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"or": []interface{}{"foo", "bar"}}}})
+func TestProcessInvalidOrMapConditionTypeFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"or": []interface{}{"foo", "bar"}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"and": map[string]interface{}{"var.firstName": "Fabien", "foo": "bar"}}}})
+func TestProcessInvalidNonArrayConditionTypeFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"and": map[string]interface{}{"var.firstName": "Fabien", "foo": "bar"}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"and": []interface{}{"INSeRT"}}}})
+func TestProcessInvalidArrayConditionFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"and": []interface{}{"INSeRT"}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"eq": 1}}}})
+func TestProcessInvalidEqIntFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"eq": 1}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"neq": 1}}}})
+func TestProcessInvalidNeqIntFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"neq": 1}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"gt": 1}}}})
+func TestProcessInvalidGtIntFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"gt": 1}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"gte": 1}}}})
+func TestProcessInvalidGteIntFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"gte": 1}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"lt": 1}}}})
+func TestProcessInvalidLtIntFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"lt": 1}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"lte": 1}}}})
+func TestProcessInvalidLteIntFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"money": map[string]interface{}{"lte": 1}}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"not": 1}}})
+func TestProcessInvalidNotIntFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(&Filter{Where: []map[string]interface{}{{"not": 1}}})
 	r.Error(err)
 	a.Nil(p)
+}
 
-	p, err = fp.Process(nil)
+func TestProcessNilFilter(t *testing.T) {
+	_, r := newAssertRequire(t)
+	_, err := fp.Process(nil)
 	r.NoError(err)
+}
+
+func TestEscapeString(t *testing.T) {
+	a, _ := newAssertRequire(t)
+	s := escapeString("O'Hare")
+	a.Equal("O\\'Hare", s)
 }


### PR DESCRIPTION
- improve error messages
- prefix like condition with operator to match other conditions
- escape all string input parameters
- break up tests for readability
- add escape and like test cases

This PR covers more than one thing, which I know is not ideal but I got fixing and creating tests and wanted the code to be fixed to ensure all the tests passed.