### PR TITLE
Quote attribute names

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ AQL:
 ```
 LIMIT 1, 2
 SORT var.age DESC, var.money ASC
-FILTER var.firstName == 'Pierre' && (var.birthPlace IN ['Paris', 'Los Angeles'] || var.age >= 18) && LIKE(var.lastName, 'R%', true)
+FILTER var.'firstName' == 'Pierre' && (var.'birthPlace' IN ['Paris', 'Los Angeles'] || var.'age' >= 18) && LIKE(var.'lastName', 'R%', true)
 ```
 
 ## Operators

--- a/filter_processor.go
+++ b/filter_processor.go
@@ -87,7 +87,7 @@ func (fp *filterProcessor) Process(f *Filter) (*processedFilter, error) {
 				split[1] = strings.ToUpper(split[1])
 			}
 
-			processedSort = fmt.Sprintf("%s%s.%s %s, ", processedSort, fp.VarName, split[0], split[1])
+			processedSort = fmt.Sprintf("%s%s.'%s' %s, ", processedSort, fp.VarName, split[0], split[1])
 		}
 
 		pf.Sort = processedSort[:len(processedSort)-2]
@@ -239,7 +239,7 @@ func (fp *filterProcessor) processUnaryCondition(buffer *bytes.Buffer, attribute
 			buffer.WriteString("LIKE(")
 			buffer.WriteString(fp.VarName)
 			buffer.WriteRune('.')
-			buffer.WriteString(paramMap["text"].(string))
+			fp.writeQuotedString(buffer, paramMap["text"].(string))
 			buffer.WriteString(", ")
 			fp.writeQuotedString(buffer, paramMap["search"].(string))
 			caseInsensitive, ok := paramMap["case_insensitive"]
@@ -297,7 +297,7 @@ func (fp *filterProcessor) processOperation(buffer *bytes.Buffer, attribute, ope
 	case []interface{}:
 		buffer.WriteString(fp.VarName)
 		buffer.WriteRune('.')
-		buffer.WriteString(attribute)
+		fp.writeQuotedString(buffer, attribute)
 		buffer.WriteString(inArrayAQL + openArrayAQL)
 
 		for i, c := range condition {
@@ -338,7 +338,7 @@ func (fp *filterProcessor) processOperation(buffer *bytes.Buffer, attribute, ope
 func (fp *filterProcessor) processSimpleOperation(buffer *bytes.Buffer, attribute, sign, condition string) {
 	buffer.WriteString(fp.VarName)
 	buffer.WriteRune('.')
-	buffer.WriteString(attribute)
+	fp.writeQuotedString(buffer, attribute)
 	buffer.WriteString(sign)
 	buffer.WriteString(condition)
 }
@@ -346,7 +346,7 @@ func (fp *filterProcessor) processSimpleOperation(buffer *bytes.Buffer, attribut
 func (fp *filterProcessor) processSimpleOperationStr(buffer *bytes.Buffer, attribute, sign, condition string) {
 	buffer.WriteString(fp.VarName)
 	buffer.WriteRune('.')
-	buffer.WriteString(attribute)
+	fp.writeQuotedString(buffer, attribute)
 	buffer.WriteString(sign)
 	fp.writeQuotedString(buffer, condition)
 }

--- a/filter_processor.go
+++ b/filter_processor.go
@@ -359,7 +359,7 @@ func (fp *filterProcessor) writeQuotedString(buffer *bytes.Buffer, str string) {
 
 func (fp *filterProcessor) writeQuotedAttribute(buffer *bytes.Buffer, str string) {
 	buffer.WriteRune('`')
-	buffer.WriteString(escapeString(str))
+	buffer.WriteString(escapeAttribute(str))
 	buffer.WriteRune('`')
 }
 

--- a/filter_processor.go
+++ b/filter_processor.go
@@ -87,7 +87,7 @@ func (fp *filterProcessor) Process(f *Filter) (*processedFilter, error) {
 				split[1] = strings.ToUpper(split[1])
 			}
 
-			processedSort = fmt.Sprintf("%s%s.'%s' %s, ", processedSort, fp.VarName, split[0], split[1])
+			processedSort = fmt.Sprintf("%s%s.`%s` %s, ", processedSort, fp.VarName, split[0], split[1])
 		}
 
 		pf.Sort = processedSort[:len(processedSort)-2]
@@ -239,7 +239,7 @@ func (fp *filterProcessor) processUnaryCondition(buffer *bytes.Buffer, attribute
 			buffer.WriteString("LIKE(")
 			buffer.WriteString(fp.VarName)
 			buffer.WriteRune('.')
-			fp.writeQuotedString(buffer, paramMap["text"].(string))
+			fp.writeQuotedAttribute(buffer, paramMap["text"].(string))
 			buffer.WriteString(", ")
 			fp.writeQuotedString(buffer, paramMap["search"].(string))
 			caseInsensitive, ok := paramMap["case_insensitive"]
@@ -297,7 +297,7 @@ func (fp *filterProcessor) processOperation(buffer *bytes.Buffer, attribute, ope
 	case []interface{}:
 		buffer.WriteString(fp.VarName)
 		buffer.WriteRune('.')
-		fp.writeQuotedString(buffer, attribute)
+		fp.writeQuotedAttribute(buffer, attribute)
 		buffer.WriteString(inArrayAQL + openArrayAQL)
 
 		for i, c := range condition {
@@ -338,7 +338,7 @@ func (fp *filterProcessor) processOperation(buffer *bytes.Buffer, attribute, ope
 func (fp *filterProcessor) processSimpleOperation(buffer *bytes.Buffer, attribute, sign, condition string) {
 	buffer.WriteString(fp.VarName)
 	buffer.WriteRune('.')
-	fp.writeQuotedString(buffer, attribute)
+	fp.writeQuotedAttribute(buffer, attribute)
 	buffer.WriteString(sign)
 	buffer.WriteString(condition)
 }
@@ -346,7 +346,7 @@ func (fp *filterProcessor) processSimpleOperation(buffer *bytes.Buffer, attribut
 func (fp *filterProcessor) processSimpleOperationStr(buffer *bytes.Buffer, attribute, sign, condition string) {
 	buffer.WriteString(fp.VarName)
 	buffer.WriteRune('.')
-	fp.writeQuotedString(buffer, attribute)
+	fp.writeQuotedAttribute(buffer, attribute)
 	buffer.WriteString(sign)
 	fp.writeQuotedString(buffer, condition)
 }
@@ -355,6 +355,12 @@ func (fp *filterProcessor) writeQuotedString(buffer *bytes.Buffer, str string) {
 	buffer.WriteRune('\'')
 	buffer.WriteString(escapeString(str))
 	buffer.WriteRune('\'')
+}
+
+func (fp *filterProcessor) writeQuotedAttribute(buffer *bytes.Buffer, str string) {
+	buffer.WriteRune('`')
+	buffer.WriteString(escapeString(str))
+	buffer.WriteRune('`')
 }
 
 func (fp *filterProcessor) checkAndOrCondition(condition interface{}) ([]map[string]interface{}, error) {
@@ -445,4 +451,8 @@ func (fp *filterProcessor) checkAQLOperators(op string, c chan error) {
 
 func escapeString(str string) string {
 	return strings.Replace(str, "'", "\\'", -1)
+}
+
+func escapeAttribute(str string) string {
+	return strings.Replace(str, "`", "\\`", -1)
 }

--- a/filter_processor_test.go
+++ b/filter_processor_test.go
@@ -345,3 +345,9 @@ func TestEscapeString(t *testing.T) {
 	s := escapeString("O'Hare")
 	a.Equal("O\\'Hare", s)
 }
+
+func TestEscapeAttribute(t *testing.T) {
+	a, _ := newAssertRequire(t)
+	s := escapeAttribute("O`Hare")
+	a.Equal("O\\`Hare", s)
+}

--- a/filter_processor_test.go
+++ b/filter_processor_test.go
@@ -89,6 +89,17 @@ var likeWhereFilter = &Filter{
 	},
 }
 
+var mixedLikeWhereFilter = &Filter{
+	Where: []map[string]interface{}{
+		{"like": map[string]interface{}{
+			"text":             "firstName",
+			"search":           "%fab%",
+			"case_insensitive": true,
+		}},
+		{"archived": map[string]interface{}{"eq": false}},
+	},
+}
+
 func newAssertRequire(t *testing.T) (*assert.Assertions, *require.Assertions) {
 	a := assert.New(t)
 	r := require.New(t)
@@ -135,7 +146,7 @@ func TestProcessSortFilter(t *testing.T) {
 	a, r := newAssertRequire(t)
 	p, err := fp.Process(sortFilter)
 	r.NoError(err)
-	a.Equal("var.firstName ASC, var.lastName DESC, var.age ASC", p.Sort)
+	a.Equal("var.'firstName' ASC, var.'lastName' DESC, var.'age' ASC", p.Sort)
 }
 
 func TestProcessEmptySortFilter(t *testing.T) {
@@ -166,16 +177,16 @@ func TestProcessBasicWhereFilter(t *testing.T) {
 	split := strings.Split(p.Where, " && ")
 	a.Equal(10, len(split))
 	expected := []string{
-		`var.awesome == true`,
-		`var.graduated IN [2010, 2015]`,
-		`var.avg IN [15.5, 13.24]`,
-		`var.birthPlace IN ['Chalon', 'Macon']`,
-		`var.password == 'qwertyuiop'`,
-		`var.age == 22`,
-		`var.money == 3000.55`,
-		`var.notAwesome == false`,
-		`var.bools IN [true, false]`,
-		`var.strWithQuote == 'O\'Hare'`,
+		`var.'awesome' == true`,
+		`var.'graduated' IN [2010, 2015]`,
+		`var.'avg' IN [15.5, 13.24]`,
+		`var.'birthPlace' IN ['Chalon', 'Macon']`,
+		`var.'password' == 'qwertyuiop'`,
+		`var.'age' == 22`,
+		`var.'money' == 3000.55`,
+		`var.'notAwesome' == false`,
+		`var.'bools' IN [true, false]`,
+		`var.'strWithQuote' == 'O\'Hare'`,
 	}
 	for _, s := range split {
 		a.Contains(expected, s)
@@ -186,14 +197,14 @@ func TestProcessOrWhereFilter(t *testing.T) {
 	a, r := newAssertRequire(t)
 	p, err := fp.Process(orWhereFilter)
 	r.NoError(err)
-	a.Equal(`(var.lastName == 'O\'Connor' || var.age > 23 || var.age < 26)`, p.Where)
+	a.Equal(`(var.'lastName' == 'O\'Connor' || var.'age' > 23 || var.'age' < 26)`, p.Where)
 }
 
 func TestProcessAndWhereFilter(t *testing.T) {
 	a, r := newAssertRequire(t)
 	p, err := fp.Process(andWhereFilter)
 	r.NoError(err)
-	a.Equal(`(var.firstName != 'Toto' && var.money == 200.5)`, p.Where)
+	a.Equal(`(var.'firstName' != 'Toto' && var.'money' == 200.5)`, p.Where)
 }
 
 func TestProcessNotWhereFilter(t *testing.T) {
@@ -203,8 +214,8 @@ func TestProcessNotWhereFilter(t *testing.T) {
 	split := strings.Split(p.Where, " && ")
 	a.Equal(2, len(split))
 	expected := []string{
-		`!(var.firstName == 'D\'Arcy')`,
-		`!((var.lastName == 'Herfray' || var.money >= 0 || var.money <= 1000.5))`,
+		`!(var.'firstName' == 'D\'Arcy')`,
+		`!((var.'lastName' == 'Herfray' || var.'money' >= 0 || var.'money' <= 1000.5))`,
 	}
 	for _, s := range split {
 		a.Contains(expected, s)
@@ -217,8 +228,22 @@ func TestProcessLikeWhereFilter(t *testing.T) {
 	r.NoError(err)
 	split := strings.Split(p.Where, " && ")
 	expected := []string{
-		`LIKE(var.firstName, 'fab%', true)`,
-		`LIKE(var.lastName, 'Her%')`,
+		`LIKE(var.'firstName', 'fab%', true)`,
+		`LIKE(var.'lastName', 'Her%')`,
+	}
+	for _, s := range split {
+		a.Contains(expected, s)
+	}
+}
+
+func TestProcessMixedLikeWhereFilter(t *testing.T) {
+	a, r := newAssertRequire(t)
+	p, err := fp.Process(mixedLikeWhereFilter)
+	r.NoError(err)
+	split := strings.Split(p.Where, " && ")
+	expected := []string{
+		`LIKE(var.'firstName', '%fab%', true)`,
+		`var.'archived' == false`,
 	}
 	for _, s := range split {
 		a.Contains(expected, s)

--- a/filter_processor_test.go
+++ b/filter_processor_test.go
@@ -146,7 +146,7 @@ func TestProcessSortFilter(t *testing.T) {
 	a, r := newAssertRequire(t)
 	p, err := fp.Process(sortFilter)
 	r.NoError(err)
-	a.Equal("var.'firstName' ASC, var.'lastName' DESC, var.'age' ASC", p.Sort)
+	a.Equal("var.`firstName` ASC, var.`lastName` DESC, var.`age` ASC", p.Sort)
 }
 
 func TestProcessEmptySortFilter(t *testing.T) {
@@ -177,16 +177,16 @@ func TestProcessBasicWhereFilter(t *testing.T) {
 	split := strings.Split(p.Where, " && ")
 	a.Equal(10, len(split))
 	expected := []string{
-		`var.'awesome' == true`,
-		`var.'graduated' IN [2010, 2015]`,
-		`var.'avg' IN [15.5, 13.24]`,
-		`var.'birthPlace' IN ['Chalon', 'Macon']`,
-		`var.'password' == 'qwertyuiop'`,
-		`var.'age' == 22`,
-		`var.'money' == 3000.55`,
-		`var.'notAwesome' == false`,
-		`var.'bools' IN [true, false]`,
-		`var.'strWithQuote' == 'O\'Hare'`,
+		"var.`awesome` == true",
+		"var.`graduated` IN [2010, 2015]",
+		"var.`avg` IN [15.5, 13.24]",
+		"var.`birthPlace` IN ['Chalon', 'Macon']",
+		"var.`password` == 'qwertyuiop'",
+		"var.`age` == 22",
+		"var.`money` == 3000.55",
+		"var.`notAwesome` == false",
+		"var.`bools` IN [true, false]",
+		"var.`strWithQuote` == 'O\\'Hare'",
 	}
 	for _, s := range split {
 		a.Contains(expected, s)
@@ -197,14 +197,14 @@ func TestProcessOrWhereFilter(t *testing.T) {
 	a, r := newAssertRequire(t)
 	p, err := fp.Process(orWhereFilter)
 	r.NoError(err)
-	a.Equal(`(var.'lastName' == 'O\'Connor' || var.'age' > 23 || var.'age' < 26)`, p.Where)
+	a.Equal("(var.`lastName` == 'O\\'Connor' || var.`age` > 23 || var.`age` < 26)", p.Where)
 }
 
 func TestProcessAndWhereFilter(t *testing.T) {
 	a, r := newAssertRequire(t)
 	p, err := fp.Process(andWhereFilter)
 	r.NoError(err)
-	a.Equal(`(var.'firstName' != 'Toto' && var.'money' == 200.5)`, p.Where)
+	a.Equal("(var.`firstName` != 'Toto' && var.`money` == 200.5)", p.Where)
 }
 
 func TestProcessNotWhereFilter(t *testing.T) {
@@ -214,8 +214,8 @@ func TestProcessNotWhereFilter(t *testing.T) {
 	split := strings.Split(p.Where, " && ")
 	a.Equal(2, len(split))
 	expected := []string{
-		`!(var.'firstName' == 'D\'Arcy')`,
-		`!((var.'lastName' == 'Herfray' || var.'money' >= 0 || var.'money' <= 1000.5))`,
+		"!(var.`firstName` == 'D\\'Arcy')",
+		"!((var.`lastName` == 'Herfray' || var.`money` >= 0 || var.`money` <= 1000.5))",
 	}
 	for _, s := range split {
 		a.Contains(expected, s)
@@ -228,8 +228,8 @@ func TestProcessLikeWhereFilter(t *testing.T) {
 	r.NoError(err)
 	split := strings.Split(p.Where, " && ")
 	expected := []string{
-		`LIKE(var.'firstName', 'fab%', true)`,
-		`LIKE(var.'lastName', 'Her%')`,
+		"LIKE(var.`firstName`, 'fab%', true)",
+		"LIKE(var.`lastName`, 'Her%')",
 	}
 	for _, s := range split {
 		a.Contains(expected, s)
@@ -242,8 +242,8 @@ func TestProcessMixedLikeWhereFilter(t *testing.T) {
 	r.NoError(err)
 	split := strings.Split(p.Where, " && ")
 	expected := []string{
-		`LIKE(var.'firstName', '%fab%', true)`,
-		`var.'archived' == false`,
+		"LIKE(var.`firstName`, '%fab%', true)",
+		"var.`archived` == false",
 	}
 	for _, s := range split {
 		a.Contains(expected, s)

--- a/filter_test.go
+++ b/filter_test.go
@@ -43,7 +43,7 @@ func TestToAQL(t *testing.T) {
 	aqlFilter, err := ToAQL("", filter)
 	r.NoError(err)
 	a.EqualValues(
-		`FILTER var.'age' >= 18 SORT var.'age' DESC, var.'money' ASC LIMIT 1, 2`,
+		"FILTER var.`age` >= 18 SORT var.`age` DESC, var.`money` ASC LIMIT 1, 2",
 		aqlFilter)
 
 	aqlFilter, err = ToAQL("var", &Filter{})

--- a/filter_test.go
+++ b/filter_test.go
@@ -43,7 +43,7 @@ func TestToAQL(t *testing.T) {
 	aqlFilter, err := ToAQL("", filter)
 	r.NoError(err)
 	a.EqualValues(
-		`FILTER var.age >= 18 SORT var.age DESC, var.money ASC LIMIT 1, 2`,
+		`FILTER var.'age' >= 18 SORT var.'age' DESC, var.'money' ASC LIMIT 1, 2`,
 		aqlFilter)
 
 	aqlFilter, err = ToAQL("var", &Filter{})


### PR DESCRIPTION
I've discovered a minor issue where input like `{"where": {"field /*": "value"}}` can cause errors. Obviously this is unlikely to be a real attribute but the concern is that it might be used maliciously (though I can't see any obvious way to do this). There are various other field names that could cause errors but the solution is to always quote fields like "var.\`field /*\`".